### PR TITLE
Use xml file base name for output file path instead of sample name

### DIFF
--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -4,7 +4,7 @@ id: foundation-ingest
 label: foundation-ingest
 hints:
   DockerRequirement:
-    dockerPull: lifeomic/foundation-ingest:1.0.3
+    dockerPull: lifeomic/foundation-ingest:1.0.4
 
 inputs:
   xmlFile:

--- a/src/run.py
+++ b/src/run.py
@@ -6,6 +6,7 @@ import os
 import xmltodict
 import yaml
 import shutil
+from pathlib import Path
 from util.log import logger
 from util.vcf import extract_vcf
 from util.cnv import extract_copy_numbers
@@ -53,8 +54,10 @@ def process(results_payload_dict, args):
 
     os.makedirs(f"{args.output}/{sample_name}", exist_ok=True)
 
+    base_xml_name = Path(args.xml_file).stem
+
     yaml_file = get_test_yml(
-        results_payload_dict, sample_name, args.output, args.source, args.includePatientInfo
+        results_payload_dict, base_xml_name, args.output, args.source, args.includePatientInfo
     )
     variants = []
 

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -61,6 +61,8 @@ def test_yml():
 
     yml = get_test_yml(xml["rr:ResultsReport"]["rr:ResultsPayload"], "SA-1612348", f"{BASE_PATH}/data", "source", "true")
 
+    print(yml)
+
     assert yml == {
         'tests': [
             {
@@ -86,23 +88,23 @@ def test_yml():
                     {
                         'type': 'shortVariant',
                         'sequenceType': 'somatic',
-                        'fileName': 'SA-1612348/SA-1612348.nrm.vcf'
+                        'fileName': '.lifeomic/foundation/SA-1612348/SA-1612348.nrm.vcf'
                     },
                     {
                         'type': 'copyNumberVariant',
                         'sequenceType': 'somatic',
-                        'fileName': 'SA-1612348/SA-1612348.copynumber.csv'
+                        'fileName': '.lifeomic/foundation/SA-1612348/SA-1612348.copynumber.csv'
                     },
                     {
                         'type': 'structuralVariant',
                         'sequenceType': 'somatic',
-                        'fileName': 'SA-1612348/SA-1612348.structural.csv'
+                        'fileName': '.lifeomic/foundation/SA-1612348/SA-1612348.structural.csv'
                     }
                 ],
                 'msi': 'stable',
                 'tmb': 'low',
                 'tmbScore': 0.73,
-                'reportFile': 'SA-1612348/SA-1612348.report.pdf'
+                'reportFile': '.lifeomic/foundation/SA-1612348/SA-1612348.report.pdf'
             }
         ]
     }

--- a/src/util/ga4gh.py
+++ b/src/util/ga4gh.py
@@ -2,13 +2,13 @@ import os
 import base64
 
 
-def get_test_yml(results_payload_dict, sample_name, output, source, includePatientInfo):
+def get_test_yml(results_payload_dict, base_xml_name, output, source, includePatientInfo):
     pmi = results_payload_dict.get("FinalReport", {}).get("PMI", {})
     sample = results_payload_dict.get("FinalReport", {}).get("Sample", {})
     variant_report = results_payload_dict.get("variant-report", {})
     biomarkers = variant_report.get("biomarkers", {})
 
-    os.makedirs(f"{output}/{sample_name}", exist_ok=True)
+    os.makedirs(f"{output}/{base_xml_name}", exist_ok=True)
 
     yaml_file = {
         "tests": [
@@ -29,17 +29,17 @@ def get_test_yml(results_payload_dict, sample_name, output, source, includePatie
                     {
                         "type": "shortVariant",
                         "sequenceType": "somatic",
-                        "fileName": f".lifeomic/foundation/{sample_name}/{sample_name}.nrm.vcf",
+                        "fileName": f".lifeomic/foundation/{base_xml_name}/{base_xml_name}.nrm.vcf",
                     },
                     {
                         "type": "copyNumberVariant",
                         "sequenceType": "somatic",
-                        "fileName": f".lifeomic/foundation/{sample_name}/{sample_name}.copynumber.csv",
+                        "fileName": f".lifeomic/foundation/{base_xml_name}/{base_xml_name}.copynumber.csv",
                     },
                     {
                         "type": "structuralVariant",
                         "sequenceType": "somatic",
-                        "fileName": f".lifeomic/foundation/{sample_name}/{sample_name}.structural.csv",
+                        "fileName": f".lifeomic/foundation/{base_xml_name}/{base_xml_name}.structural.csv",
                     },
                 ],
             }
@@ -80,13 +80,13 @@ def get_test_yml(results_payload_dict, sample_name, output, source, includePatie
 
     if "ReportPDF" in results_payload_dict:
         pdf = base64.b64decode(results_payload_dict["ReportPDF"])
-        report_file = f"{output}/{sample_name}/{sample_name}.report.pdf"
+        report_file = f"{output}/{base_xml_name}/{base_xml_name}.report.pdf"
 
         with open(report_file, "wb") as pdf_file:
             pdf_file.write(pdf)
 
         yaml_file["tests"][0][
             "reportFile"
-        ] = f".lifeomic/foundation/{sample_name}/{sample_name}.report.pdf"
+        ] = f".lifeomic/foundation/{base_xml_name}/{base_xml_name}.report.pdf"
 
     return yaml_file


### PR DESCRIPTION
Using the xml file name in the path will make it easier to match up BAM files later that have the same base name. 